### PR TITLE
Update to build with new agda/agda-stdlib

### DIFF
--- a/Data/BitVector/NumericOrder.agda
+++ b/Data/BitVector/NumericOrder.agda
@@ -214,6 +214,5 @@ strictTotalOrder {n} = record
       { isEquivalence = isEquivalence
       ; trans         = <-trans
       ; compare       = compare
-      ; <-resp-≈      = resp₂ _<_
       }
   }

--- a/bitvector.agda-lib
+++ b/bitvector.agda-lib
@@ -1,0 +1,3 @@
+name: bitvector
+include: .
+depend: standard-library


### PR DESCRIPTION
Agda 2.5 uses library files (ala bitvector.agda-lib) to deal with paths,
rather than user supplied directories.

Additionally, new agda-stdlib has dropped a field in its equivalence
type, so I dropped that as well.
